### PR TITLE
RAVE-1099 | Introduces Vagrant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.iml
+.idea/
+overlays/
+target/
+.DS_Store
+.vagrant/

--- a/README.txt
+++ b/README.txt
@@ -35,35 +35,19 @@ You need a platform that supports Java SE 6 or later.
 
 Building and running
 ====================
-To build from source code:
+To setup the vagrant development environment:
 
   - Requirements:
-    Sources compilation require Java SE 6 or higher.
-    The project is built with Apache Maven 3+ (suggested is 3.0.3).
-    You need to download and install Maven 3 from: http://maven.apache.org/
+    Vagrant v1.6.3+, Ansible 1.6.5+
 
-  - The Rave project itself (this one) depends on the separate Rave Master project
-    which defines general and global settings for the whole of the Rave project,
-    independent of a specific release.
-    As its rave-master-pom is already published to the Apache Snapshots repository,
-    there is no need to check it out manually and build it locally yourself,
-    unless changes are needed on general and global level.
-    
-    If so needed, the Rave Master project can be checked out from:
-      http://svn.apache.org/repos/asf/rave/rave-master-pom/trunk rave-master-pom
+  - Install the `vagrant-hostsupdater` plugin by performing `vagrant plugin install vagrant-hostsupdater`.
 
-    After check out, cd into rave-master-pom and invoke maven to install it using:
-      $mvn install
-    
-  - To build the Rave project invoke maven in the root directory:
-      $mvn install
+  - To build the virtual machine, simply run `vagrant up`.
 
-To run a local Tomcat instance with rave-shindig and rave-portal deployed:
+To run the apache rave application:
 
-  - from the top-level rave directory, use the command
-      $mvn cargo:run -f rave-portal/pom.xml
-  - alternatively, navigate to the rave-portal subdirectory and invoke:
-      $mvn cargo:run
-  - open url http://localhost:8080/ in a browser
-  - press Ctrl-C in the console to stop Tomcat again
---------------------------------------------------------------------------------
+  - SSH into the vagrant box
+  - Run the following command to start the rave portal
+      `mvn cargo:run -f /rave/rave-portal/pom.xml`
+  - open url http://rave.dev:8080/portal in a browser
+  - press Ctrl-C in the console to stop the application

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Pathing variables
+vagrant_dir = File.expand_path(File.dirname(__FILE__))
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.provider :virtualbox do |v|
+    v.customize ["modifyvm", :id, "--memory", 1024]
+  end
+
+  config.ssh.forward_agent = true
+  config.vm.hostname = "rave.dev"
+  config.vm.network :private_network, ip: "192.168.13.37"
+  config.vm.box = "hashicorp/precise64"
+
+  # load the project into the Vagrant
+  config.vm.synced_folder vagrant_dir, "/rave/", :mount_options => [ "dmode=775", "fmode=774" ]
+
+  if defined? VagrantPlugins::HostsUpdater
+    config.hostsupdater.aliases = ["rave.dev"]
+  end
+
+  # Provision
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "deploy/ansible/rave-local-playbook.yml"
+  end
+
+end

--- a/deploy/ansible/rave-local-playbook.yml
+++ b/deploy/ansible/rave-local-playbook.yml
@@ -1,0 +1,11 @@
+---
+-
+  hosts: all
+  sudo: yes
+  vars:
+    app_base_path: "/rave/"
+    default_user: "rave"
+  roles:
+    - oracle-java7
+    - maven
+    - tomcat7

--- a/deploy/ansible/roles/maven/tasks/main.yml
+++ b/deploy/ansible/roles/maven/tasks/main.yml
@@ -1,0 +1,40 @@
+# install maven
+- name: Check whether or not maven is currently installed
+  shell: "[ -d {{ maven_install_dir }}/{{ maven_extracted_dirname }} ] && echo 'Found' || echo ''"
+  register: mvn_installed
+  changed_when: mvn_installed.stdout == ""
+  tags: maven
+
+- name: Create a maven directory
+  file: path={{ maven_install_dir }} owner=root group=root mode=0775 state=directory
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Download maven
+  get_url: dest={{ maven_install_dir }}/{{ maven_download_filename }} url={{ maven_download_url }}
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Extract maven archive file
+  command: creates={{ maven_install_dir }}/{{ maven_extracted_dirname }} chdir={{ maven_install_dir }} tar zxvf {{ maven_install_dir }}/{{ maven_download_filename }} --owner=root
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Create a maven latest symlink
+  file: src={{ maven_install_dir }}/{{ maven_extracted_dirname }} dest={{ maven_install_dir }}/latest owner=root group=root state=link
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Copy config maven.sh
+  action: template src=maven.sh dest=/etc/profile.d/maven.sh owner=root group=root mode=0644
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Cleanup maven archive file
+  file: path={{ maven_install_dir }}/{{ maven_download_filename }} state=absent
+  when: (not mvn_installed.stdout)
+  tags: maven
+
+- name: Install maven dependencies for apache rave
+  command: /usr/local/maven/latest/bin/mvn install chdir={{ maven_rave_dir }} creates={{ maven_rave_dir }}/target
+  tags: maven

--- a/deploy/ansible/roles/maven/templates/maven.sh
+++ b/deploy/ansible/roles/maven/templates/maven.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# {{ ansible_managed }}
+
+export M3_HOME={{ maven_install_dir }}/latest
+export M3=$M3_HOME/bin
+export MAVEN_OPTS="-Xms{{ maven_min_memory }} -Xmx{{ maven_max_memory }}"
+export PATH=$M3:$PATH
+~

--- a/deploy/ansible/roles/maven/vars/main.yml
+++ b/deploy/ansible/roles/maven/vars/main.yml
@@ -1,0 +1,10 @@
+maven_version: 3.1.1
+maven_min_memory: 256m
+maven_max_memory: 512m
+maven_install_dir: /usr/local/maven
+maven_rave_dir: /rave/rave-portal
+maven_major_version: 3
+maven_base_download_url: "http://apache.mirrors.tds.net/maven/maven-{{ maven_major_version }}/{{ maven_version }}/binaries/"
+maven_extracted_dirname: "apache-maven-{{ maven_version }}"
+maven_download_filename: "apache-maven-{{ maven_version }}-bin.tar.gz"
+maven_download_url: "{{ maven_base_download_url }}/{{ maven_download_filename }}"

--- a/deploy/ansible/roles/oracle-java7/tasks/main.yml
+++ b/deploy/ansible/roles/oracle-java7/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Check whether or not oracle-java7 is currently installed
+  shell: "[ -d /usr/lib/jvm/java-7-oracle ] && echo 'Found' || echo ''"
+  register: oracle_java_installed
+  changed_when: oracle_java_installed.stdout == ""
+  tags: oracle-java7
+
+- name: Add oracle java repository
+  apt_repository: repo="ppa:webupd8team/java" update_cache=yes
+  when: (not oracle_java_installed.stdout)
+  tags: oracle-java7
+
+- name: Accept the oracle license
+  debconf: name="oracle-java7-installer" question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+  when: (not oracle_java_installed.stdout)
+  tags: oracle-java7
+
+- name: Install packages
+  apt: name={{item}} state=present update_cache=yes
+  with_items: oracle_packages
+  when: (not oracle_java_installed.stdout)
+  tags: oracle-java7

--- a/deploy/ansible/roles/oracle-java7/vars/main.yml
+++ b/deploy/ansible/roles/oracle-java7/vars/main.yml
@@ -1,0 +1,3 @@
+oracle_packages:
+    - oracle-java7-installer
+    - oracle-java7-set-default

--- a/deploy/ansible/roles/tomcat7/handlers/main.yml
+++ b/deploy/ansible/roles/tomcat7/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: tomcat7-restart
+  service: name=tomcat7 state=restarted

--- a/deploy/ansible/roles/tomcat7/tasks/main.yml
+++ b/deploy/ansible/roles/tomcat7/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Check whether or not Java 1.7 is installed
+  shell: "[ -d /usr/lib/jvm/java-7-openjdk-amd64 ] && echo 'Found' || echo ''"
+  register: jdk_installed
+  changed_when: jdk_installed.stdout == ""
+  tags: tomcat7-jdk
+
+- name: Install Java 1.7
+  apt: pkg=openjdk-7-jdk state=present
+  when: (not jdk_installed.stdout)
+  tags: tomcat7-jdk
+
+- name: Check whether or not Tomcat7 is installed
+  shell: "[ -d /etc/tomcat7 ] && echo 'Found' || echo ''"
+  register: tomcat_installed
+  changed_when: tomcat_installed.stdout == ""
+  tags: tomcat7
+
+- name: Update apt cache
+  apt: update_cache=yes
+  when: (not tomcat_installed.stdout)
+  tags: tomcat7
+
+- name: Install Tomcat 7
+  apt: pkg=tomcat7 state=present
+  when: (not tomcat_installed.stdout)
+  tags: tomcat7
+
+- name: Install Tomcat 7 Admin Interface
+  apt: pkg=tomcat7-admin state=present
+  when: (not tomcat_installed.stdout)
+  tags: tomcat7
+
+- name: Configure Tomcat 7 Users
+  template: src=tomcat-users.xml dest=/etc/tomcat7/
+  when: (not tomcat_installed.stdout)
+  tags: tomcat7
+
+- name: Load custom configuration for tomcat7
+  template: src=server.xml dest=/etc/tomcat7/
+  notify: tomcat7-restart
+  when: (not tomcat_installed.stdout)
+  tags: tomcat7

--- a/deploy/ansible/roles/tomcat7/templates/server.xml
+++ b/deploy/ansible/roles/tomcat7/templates/server.xml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <!--
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  -->
+  <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
+  <Listener className="org.apache.catalina.core.JasperListener" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="{{ tomcat_default_port }}" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               URIEncoding="UTF-8"
+               redirectPort="8443" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL HTTP/1.1 Connector on port 8443
+         This connector uses the JSSE configuration, when using APR, the
+         connector should be using the OpenSSL style configuration
+         described in the APR documentation -->
+    <!--
+    <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
+               maxThreads="150" scheme="https" secure="true"
+               clientAuth="false" sslProtocol="TLS" />
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    -->
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log." suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/deploy/ansible/roles/tomcat7/templates/tomcat-users.xml
+++ b/deploy/ansible/roles/tomcat7/templates/tomcat-users.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+
+<!-- {{ ansible_managed }} -->
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users>
+
+  <user username="{{ tomcat_admin_username }}" password="{{ tomcat_admin_password }}" roles="manager-gui" />
+
+</tomcat-users>

--- a/deploy/ansible/roles/tomcat7/vars/main.yml
+++ b/deploy/ansible/roles/tomcat7/vars/main.yml
@@ -1,0 +1,3 @@
+tomcat_admin_username: rave
+tomcat_admin_password: rave
+tomcat_default_port: 8200


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/RAVE-1099

This PR introduces vagrant so we don't need to install dependencies on our local machine; now, everything is sandboxed. The vagrant box will use the maven 3.3.1, tomcat7, and oracle's java7 packages. @jmeas and I replaced the information in the `readme.txt` to accurately portray how to start up the vagrant box.

Let me know if this is the appropriate forum for submitting a PR or if we need to send our PR (and how) to the mailing lists.
