### PR TITLE
[RAVE-1101] - Introduces Grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ overlays/
 target/
 .DS_Store
 .vagrant/
+node_modules

--- a/README.txt
+++ b/README.txt
@@ -38,17 +38,18 @@ Building and running
 To setup the vagrant development environment:
 
   - Requirements:
-    Vagrant v1.6.3+, Ansible 1.6.5+
+    Vagrant v1.6.3+, Ansible 1.6.5+, Node 0.10.0+, Grunt 0.4.0+
 
   - Install the `vagrant-hostsupdater` plugin by performing `vagrant plugin install vagrant-hostsupdater`.
 
   - To build the virtual machine, simply run `vagrant up`.
 
+  - Run `npm install` from the root directory.
+
 To run the apache rave application:
 
-  - SSH into the vagrant box
-  - Run the following command to start the rave portal
-      `sudo mvn cargo:run -f /rave/rave-portal/pom.xml`
+  - Run `grunt dev` from the command line.
+  - If this is your first time building, wait up to 20 minutes. Otherwise, give it 5minutes or so.
   - open url http://rave.dev:8080/portal in a browser
   - Login as user `canonical` with the password `canonical`
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,8 +2,17 @@ module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt);
 
   grunt.initConfig({
-
+    vagrantssh: {
+      server: {
+        commands: [
+          'sudo mvn cargo:run -f /rave/rave-portal/pom.xml',
+        ],
+        callback: function(grunt, output) {
+          grunt.log.writeln('The app is running at rave.dev:8080/portal.');
+        }
+      }
+    }
   });
 
-  grunt.registerTask('default', []);
+  grunt.registerTask('dev', ['vagrantssh']);
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rave",
+  "version": "0.23.0",
+  "description": "A new web and social mashup engine that aggregates and serves web widgets.",
+  "main": "index.js",
+  "homepage": "https://rave.apache.org/",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://git-wip-us.apache.org/repos/asf/rave"
+  },
+  "author": "",
+  "license": "Apache License 2.0",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-vagrant-ssh": "^0.1.0",
+    "load-grunt-tasks": "^0.6.0"
+  }
+}


### PR DESCRIPTION
**NOTE:** #3 should go in first.

This adds Grunt to the project. Eventually we'll use it for a lot more. Presently it just gets the webserver running. An issue right now is the lack of feedback for the `cargo:run` task. This task takes quite some time to get up and running, so you sort of have to 'guess' when it's time to open the app in the browser.

In a future update we can 'sniff' the output of the task on the Vagrantbox to give the user feedback when the app is ready. But that will be v2. @carldanley, do you have any idea how we might implement that functionality?
