### PR TITLE
RAVE-1087 | Dragging and dropping an OpenSocial gadget causes its iframe contents to disappear

### DIFF
--- a/rave-portal-resources/src/main/webapp/static/script/portal/rave_ui.js
+++ b/rave-portal-resources/src/main/webapp/static/script/portal/rave_ui.js
@@ -232,7 +232,7 @@ define(["jquery", "underscore", "rave",
                 uiState.currentRegion = ravePortal.getObjectIdFromDomId(ui.item.parent().get(0).id);
 
                 // Workaround for SHINDIG-1965 to keep the iframe re-parenting from firing the load events again
-                $(widgetEl).find('iframe').removeAttr('onload');
+                $(widgetEl).find('iframe').get(0).onload = function() {};
 
                 //for every drag operation, create an overlay for each iframe
                 //to prevent the iframe from intercepting mouse events


### PR DESCRIPTION
This was reviewed on [reviews.a.o](https://reviews.apache.org/r/18212/) but never got merged.
