### PR TITLE
RAVE-1093 | Toolbar action contributions' tooltips don't appear

### DIFF
--- a/rave-portal-resources/src/main/webapp/static/script/portal/rave_ui.js
+++ b/rave-portal-resources/src/main/webapp/static/script/portal/rave_ui.js
@@ -972,7 +972,7 @@ define(["jquery", "underscore", "rave",
             } else {
                 elem = "<a>" + label + "</a>";
             }
-            return $(elem).attr("tooltip", tooltip);
+            return $(elem).attr("title", tooltip);
         }
 
         function insertWidgetToolbarAction(widgetId, label, image, tooltip, id, onSelected) {


### PR DESCRIPTION
This is a carry over from [reviews.a.o](https://reviews.apache.org/r/18362/)
