### PR TITLE
RAVE-1291 | Upgrade Shindig to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </scm>
 
     <properties>
-        <apache.shindig.version>2.5.0-update1</apache.shindig.version>
+        <apache.shindig.version>2.5.1</apache.shindig.version>
         <apache.wookie.version>0.13.1</apache.wookie.version>
         <org.springframework.version>3.2.3.RELEASE</org.springframework.version>
         <org.springframework.security.version>3.1.4.RELEASE</org.springframework.security.version>


### PR DESCRIPTION
No container.js or shindig.properties changes were made as part of the Shindig 2.5.1 release.
